### PR TITLE
Add embedded metadata to manifest.yaml during build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,7 +97,7 @@ jobs:
       - name: '[Prep 4] Set version'
         id: version
         run: |
-            echo "version=$(cat manifest.yml | grep version | cut -f 2 -d: | awk '{$1=$1};1')" >> $GITHUB_OUTPUT 
+            echo "version=$(cat manifest.yaml | grep version | cut -f 2 -d: | awk '{$1=$1};1')" >> $GITHUB_OUTPUT 
 
       - name: '[Prep 5] Set branchname'
         id: branch
@@ -113,6 +113,7 @@ jobs:
         with:
           pax-name: 'keyring-util'
           pax-options: '-x os390 -pp'
+          embed-build-metadata-in-file: manifest.yaml
           pax-local-workspace: './.pax'
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,57 +27,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  read-changelog:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    outputs:
-      was_updated: ${{ steps.check-change.outputs.change_detected }}
-      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-
-      - name: Check for updated CHANGELOG.md using git
-        id: check-changelog
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
-            echo "ERROR: CHANGELOG.md has not been updated."
-            echo "::set-output name=check_commit::false"
-          else
-            echo "CHANGELOG.md has been updated."
-            echo "::set-output name=check_commit::true"
-          fi
-
-      - name: check for changes
-        id: check-change
-        run: |
-          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
-            echo "No Changes detected, setting flag to false"
-            echo "::set-output name=change_detected::false"
-          else
-            echo "::set-output name=change_detected::true"
-            fi
-
-  check_changelog:
-    if: github.event_name == 'pull_request'
-    needs: read-changelog
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Verify Changelog update
-        run: |
-          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
-            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-            exit 1
-          else
-            echo "changelog was updated successfully."
-          fi
-
   build-test:
     runs-on: ubuntu-latest
     needs: check-permission

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,6 +61,8 @@ jobs:
         with:
           target-file: manifest.yaml
           metadata-format: YAML
+          branch-name: ${{ github.head_ref || '' }}
+
       - name: '[Packaging] Make pax'
         uses: zowe-actions/shared-actions/make-pax@main
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,14 +106,17 @@ jobs:
 
       - name: '[Prep 6] Prepare workflow'
         uses: zowe-actions/shared-actions/prepare-workflow@main
-      
 
+      - name: '[Prep 7] Embed build metadata'
+        uses: zowe-actions/shared-actions/embed-metadata@main
+        with:
+          target-file: manifest.yaml
+          metadata-format: YAML
       - name: '[Packaging] Make pax'
         uses: zowe-actions/shared-actions/make-pax@main
         with:
           pax-name: 'keyring-util'
           pax-options: '-x os390 -pp'
-          embed-build-metadata-in-file: manifest.yaml
           pax-local-workspace: './.pax'
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  update-changelog:
+  read-changelog:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
@@ -44,11 +44,11 @@ jobs:
         id: check-changelog
         run: |
           if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
-            echo "CHANGELOG.md has been updated."
-            echo "::set-output name=check_commit::true"
-          else
             echo "ERROR: CHANGELOG.md has not been updated."
             echo "::set-output name=check_commit::false"
+          else
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=check_commit::true"
           fi
 
       - name: check for changes
@@ -63,7 +63,7 @@ jobs:
 
   check_changelog:
     if: github.event_name == 'pull_request'
-    needs: update-changelog
+    needs: read-changelog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,33 @@
+name: Zowe Changelog Check
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+on:
+  pull_request:
+    branches: 
+      - 'master'
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 'Check CHANGELOG'
+        run: |
+          result=$(git diff "origin/${{ github.event.pull_request.base.ref }}" -- "CHANGELOG.md")
+          if [ -z "${result}" ]; then
+            echo "Please review the CHANGELOG and add an entry for this pull request if it contains changes users should be informed of."
+            echo "If there are no changes, add the 'skip-changelog' label to this pull request."
+            exit 1
+          fi
+
+

--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -28,3 +28,4 @@ cd "$SCRIPT_DIR"
 mv content bk/
 mkdir -p content
 cp bk/build/keyring-util content/
+cp bk/manifest.yaml content/

--- a/.pax/prepare-workspace.sh
+++ b/.pax/prepare-workspace.sh
@@ -30,6 +30,8 @@ rm -fr "${PAX_WORKSPACE_DIR}/content" && mkdir -p "${PAX_WORKSPACE_DIR}/content"
 
 echo "[${SCRIPT_NAME}] copying files ..."
 cp -R * "${PAX_WORKSPACE_DIR}/ascii"
+mv "${PAX_WORKSPACE_DIR}/ascii/manifest.yaml" "${PAX_WORKSPACE_DIR}/content"
+
 # move files shouldn't change encoding to IBM-1047 to content folder
 rsync -rv \
   --include '*/' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## `3.0.0`
 
+- Added manifest.yaml to PAX file which includes build metadata (#18)
 - Added Github Action build, deprecated Jenkins build (#13)
 - Added `LISTRING` command to keyring-utilities (#13)
 - Modified `EXPORT` to output password-protected .p12 private keys instead of PEMs (#13)


### PR DESCRIPTION
Fixes #14 . I left `number` out as I wasn't sure what it's trying to solve.
Fixes #15 . I copied over CHANGELOG automation from zowe-install-packaging.

Additionally fixes empty version in the pipeline.

This currently keeps the manifest.yaml in ascii, based on the assumption that the manifest is of more value to automation running off platform rather than on platform. If we need to inspect this on platform, `iconv` covers us. 